### PR TITLE
Add Dashboard layout with stats and checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# Hr_potal
+# HR Portal
+
+This repository contains a front‑end skeleton for a React based HR Portal. It uses React 18, React Router v6 and TailwindCSS. All pages and components are placeholders ready for future integration with authentication and APIs.
+
+## Available Scripts
+
+- `npm start` – start the development server
+- `npm run build` – build for production
+
+## Project Structure
+
+- `src/pages` – page components
+- `src/components` – reusable UI components
+- `src/context` – React context helpers
+- `src/hooks` – custom hooks
+- `src/utils` – static constants and helpers

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "hr-portal",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-router-dom": "^6.14.0"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HR Portal</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import Sidebar from './components/Sidebar';
+import Header from './components/Header';
+import PageContainer from './components/PageContainer';
+import DashboardPage from './pages/DashboardPage';
+import EmployeesPage from './pages/EmployeesPage';
+import OnboardingPage from './pages/OnboardingPage';
+import DocumentsPage from './pages/DocumentsPage';
+import useSidebarToggle from './hooks/useSidebarToggle';
+
+function App() {
+  const { isOpen, toggle } = useSidebarToggle();
+
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar isOpen={isOpen} toggle={toggle} />
+      <div className="flex flex-col flex-1">
+        <Header toggleSidebar={toggle} />
+        <PageContainer>
+          <Routes>
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/dashboard" element={<DashboardPage />} />
+            <Route path="/employees" element={<EmployeesPage />} />
+            <Route path="/onboarding" element={<OnboardingPage />} />
+            <Route path="/documents" element={<DocumentsPage />} />
+          </Routes>
+        </PageContainer>
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/ChecklistItem.jsx
+++ b/src/components/ChecklistItem.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function ChecklistItem({ label, completed }) {
+  return (
+    <div className="flex items-center space-x-2 p-2 border-b">
+      <input type="checkbox" checked={completed} readOnly />
+      <span>{label}</span>
+    </div>
+  );
+}
+
+export default ChecklistItem;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+function Header({ toggleSidebar }) {
+  return (
+    <header className="flex items-center justify-between p-4 border-b">
+      <button className="md:hidden" onClick={toggleSidebar} aria-label="Toggle Sidebar">
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16"></path>
+        </svg>
+      </button>
+      <div className="flex-1 mx-4 max-w-lg">
+        <input
+          type="text"
+          placeholder="Search"
+          className="w-full p-2 border rounded"
+        />
+      </div>
+      <div className="flex items-center space-x-4">
+        <button aria-label="Notifications">
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path d="M15 17h5l-1.405-1.405C18.79 15.21 18 13.702 18 12V8c0-3.314-2.686-6-6-6S6 4.686 6 8v4c0 1.702-.79 3.21-2.595 3.595L2 17h5m5 0v1a3 3 0 11-6 0v-1m6 0H9" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+      </div>
+    </header>
+  );
+}
+
+export default Header;

--- a/src/components/PageContainer.jsx
+++ b/src/components/PageContainer.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function PageContainer({ children }) {
+  return <main className="p-6 bg-gray-50 flex-1">{children}</main>;
+}
+
+export default PageContainer;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+const links = [
+  { to: '/dashboard', label: 'Dashboard' },
+  { to: '/employees', label: 'Employees' },
+  { to: '/onboarding', label: 'Onboarding' },
+  { to: '/documents', label: 'Documents' },
+];
+
+function Sidebar({ isOpen, toggle }) {
+  return (
+    <aside
+      className={`${
+        isOpen ? 'translate-x-0' : '-translate-x-full'
+      } md:translate-x-0 fixed md:static z-20 bg-gray-800 text-white w-64 h-full transition-transform duration-200`}
+    >
+      <div className="p-4 text-xl font-bold">HR Portal</div>
+      <nav className="mt-4 flex flex-col">
+        {links.map((link) => (
+          <NavLink
+            key={link.to}
+            to={link.to}
+            className={({ isActive }) =>
+              `py-2 px-4 hover:bg-gray-700 ${isActive ? 'bg-gray-700' : ''}`
+            }
+            onClick={toggle}
+          >
+            {link.label}
+          </NavLink>
+        ))}
+      </nav>
+    </aside>
+  );
+}
+
+export default Sidebar;

--- a/src/components/StatsCard.jsx
+++ b/src/components/StatsCard.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function StatsCard({ label, value }) {
+  return (
+    <div className="bg-white rounded shadow p-4 text-center">
+      <div className="text-2xl font-bold">{value}</div>
+      <div className="text-sm text-gray-600">{label}</div>
+    </div>
+  );
+}
+
+export default StatsCard;

--- a/src/context/UserContext.js
+++ b/src/context/UserContext.js
@@ -1,0 +1,17 @@
+import React, { createContext, useState, useContext } from 'react';
+
+const UserContext = createContext(null);
+
+export function UserProvider({ children }) {
+  const [role, setRole] = useState('guest');
+
+  return (
+    <UserContext.Provider value={{ role, setRole }}>
+      {children}
+    </UserContext.Provider>
+  );
+}
+
+export function useUser() {
+  return useContext(UserContext);
+}

--- a/src/hooks/useSidebarToggle.js
+++ b/src/hooks/useSidebarToggle.js
@@ -1,0 +1,9 @@
+import { useState } from 'react';
+
+export default function useSidebarToggle() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggle = () => setIsOpen((prev) => !prev);
+
+  return { isOpen, toggle };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import StatsCard from '../components/StatsCard';
+import ChecklistItem from '../components/ChecklistItem';
+import { DASHBOARD_STATS, ONBOARDING_TASKS } from '../utils/constants';
+
+function DashboardPage() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold mb-4">Dashboard</h1>
+
+      <section className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {DASHBOARD_STATS.map((stat) => (
+          <StatsCard key={stat.label} label={stat.label} value={stat.value} />
+        ))}
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Onboarding Checklist</h2>
+        <div className="bg-white rounded shadow divide-y">
+          {ONBOARDING_TASKS.map((task) => (
+            <ChecklistItem
+              key={task.id}
+              label={task.label}
+              completed={task.completed}
+            />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default DashboardPage;

--- a/src/pages/DocumentsPage.jsx
+++ b/src/pages/DocumentsPage.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function DocumentsPage() {
+  return <h1 className="text-3xl font-bold">Documents</h1>;
+}
+
+export default DocumentsPage;

--- a/src/pages/EmployeesPage.jsx
+++ b/src/pages/EmployeesPage.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function EmployeesPage() {
+  return <h1 className="text-3xl font-bold">Employees</h1>;
+}
+
+export default EmployeesPage;

--- a/src/pages/OnboardingPage.jsx
+++ b/src/pages/OnboardingPage.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function OnboardingPage() {
+  return <h1 className="text-3xl font-bold">Onboarding</h1>;
+}
+
+export default OnboardingPage;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,18 @@
+export const APP_NAME = 'HR Portal';
+
+export const MOCK_USER = {
+  name: 'Jane Doe',
+  role: 'admin',
+};
+
+export const DASHBOARD_STATS = [
+  { label: 'Employees', value: 12 },
+  { label: 'Active Onboarding', value: 3 },
+  { label: 'Pending Documents', value: 5 },
+];
+
+export const ONBOARDING_TASKS = [
+  { id: 1, label: 'Complete paperwork', completed: false },
+  { id: 2, label: 'Setup payroll', completed: true },
+  { id: 3, label: 'Sign policies', completed: false },
+];

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add `StatsCard` component
- update constants with dashboard data and onboarding tasks
- build new Dashboard layout with stats grid and onboarding checklist

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae09067f48332a76f9e98992aab06