### PR TITLE
Trigger list refresh after adding employee

### DIFF
--- a/src/context/EmployeeContext.js
+++ b/src/context/EmployeeContext.js
@@ -40,6 +40,10 @@ export function EmployeeProvider({ children }) {
 
   const [employees, setEmployees] = useState(initialEmployees);
 
+  const setEmployeesList = (list) => {
+    setEmployees(list);
+  };
+
   const addEmployee = (employee) => {
     setEmployees((prev) => [
       ...prev,
@@ -62,7 +66,13 @@ export function EmployeeProvider({ children }) {
 
   return (
     <EmployeeContext.Provider
-      value={{ employees, addEmployee, updateEmployee, deleteEmployee }}
+      value={{
+        employees,
+        addEmployee,
+        updateEmployee,
+        deleteEmployee,
+        setEmployees: setEmployeesList,
+      }}
     >
       {children}
     </EmployeeContext.Provider>

--- a/src/pages/EmployeesPage.jsx
+++ b/src/pages/EmployeesPage.jsx
@@ -7,7 +7,12 @@ import Toast from '../components/Toast';
 import EmployeesTable from '../components/EmployeesTable';
 
 function EmployeesPage() {
-  const { employees, addEmployee, updateEmployee, deleteEmployee } = useEmployees();
+  const {
+    employees,
+    updateEmployee,
+    deleteEmployee,
+    setEmployees,
+  } = useEmployees();
   const [search, setSearch] = useState('');
   const [editing, setEditing] = useState(null);
   const [showForm, setShowForm] = useState(false);
@@ -58,7 +63,14 @@ function EmployeesPage() {
       }
 
       await response.text();
-      addEmployee(data);
+
+      const listRes = await fetch('http://172.18.4.178:8000/employees');
+      if (!listRes.ok) {
+        throw new Error('Failed to fetch employees');
+      }
+      const list = await listRes.json();
+      setEmployees(list);
+
       setToast({ type: 'success', message: 'Employee added' });
       setShowForm(false);
     } catch (err) {


### PR DESCRIPTION
## Summary
- expose `setEmployees` via `EmployeeProvider`
- fetch the updated employee list after adding a new employee

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff3158bc88332ad391bf028f72c8c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Trigger a list refresh by fetching all employees immediately after adding a new employee.

### Why are these changes being made?

This change ensures the employee list is up-to-date by fetching the latest data from the server after a new employee is added, addressing synchronization issues that might arise from relying solely on local state updates. Refreshing the list immediately provides users with the most current information and aligns the UI with backend updates seamlessly.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->