### PR TITLE
Add employee service and unit tests for EmployeesPage

### DIFF
--- a/src/pages/EmployeesPage.jsx
+++ b/src/pages/EmployeesPage.jsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useEmployees } from '../context/EmployeeContext';
 import Modal from '../components/Modal';
 import EmployeeForm from '../components/EmployeeForm';
 import ConfirmDialog from '../components/ConfirmDialog';
 import Toast from '../components/Toast';
 import EmployeesTable from '../components/EmployeesTable';
+import { getEmployees, createEmployee } from '../services/employeeService';
 
 function EmployeesPage() {
   const {
@@ -24,11 +25,7 @@ function EmployeesPage() {
   useEffect(() => {
     const fetchEmployees = async () => {
       try {
-        const res = await fetch('http://172.18.4.178:8000/employees');
-        if (!res.ok) {
-          throw new Error('Failed to fetch employees');
-        }
-        const list = await res.json();
+        const list = await getEmployees();
         setEmployees(list);
       } catch (err) {
         setToast({
@@ -43,65 +40,54 @@ function EmployeesPage() {
     fetchEmployees();
   }, [setEmployees]);
 
-  const filtered = employees.filter((e) =>
-    e.name.toLowerCase().includes(search.toLowerCase())
+  const filtered = useMemo(
+    () =>
+      employees.filter((e) =>
+        e.name.toLowerCase().includes(search.toLowerCase())
+      ),
+    [employees, search]
   );
 
-  const handleAdd = () => {
+  const handleAdd = useCallback(() => {
     setEditing(null);
     setShowForm(true);
-  };
+  }, []);
 
-  const handleEdit = (emp) => {
+  const handleEdit = useCallback((emp) => {
     setEditing(emp);
     setShowForm(true);
-  };
+  }, []);
 
-  const handleSave = async (data) => {
-    if (editing) {
-      updateEmployee(editing.id, data);
-      setToast({ type: 'success', message: 'Employee updated' });
-      setShowForm(false);
-      return;
-    }
-
-    setIsSubmitting(true);
-    try {
-      const response = await fetch('http://172.18.4.178:8000/employees', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(data),
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to create employee');
+  const handleSave = useCallback(
+    async (data) => {
+      if (editing) {
+        updateEmployee(editing.id, data);
+        setToast({ type: 'success', message: 'Employee updated' });
+        setShowForm(false);
+        return;
       }
 
-      await response.text();
+      setIsSubmitting(true);
+      try {
+        const list = await createEmployee(data);
+        setEmployees(list);
 
-      const listRes = await fetch('http://172.18.4.178:8000/employees');
-      if (!listRes.ok) {
-        throw new Error('Failed to fetch employees');
+        setToast({ type: 'success', message: 'Employee added' });
+        setShowForm(false);
+      } catch (err) {
+        setToast({ type: 'error', message: err.message || 'Error adding employee' });
+      } finally {
+        setIsSubmitting(false);
       }
-      const list = await listRes.json();
-      setEmployees(list);
+    },
+    [editing, updateEmployee, setEmployees]
+  );
 
-      setToast({ type: 'success', message: 'Employee added' });
-      setShowForm(false);
-    } catch (err) {
-      setToast({ type: 'error', message: err.message || 'Error adding employee' });
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleDelete = () => {
+  const handleDelete = useCallback(() => {
     deleteEmployee(toDelete.id);
     setToast({ type: 'success', message: 'Employee deleted' });
     setToDelete(null);
-  };
+  }, [deleteEmployee, toDelete]);
 
   return (
     <div className="space-y-4">

--- a/src/pages/__tests__/EmployeesPage.test.jsx
+++ b/src/pages/__tests__/EmployeesPage.test.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { EmployeeProvider } from '../../context/EmployeeContext';
+import EmployeesPage from '../EmployeesPage';
+import * as service from '../../services/employeeService';
+
+jest.mock('../../services/employeeService');
+
+function renderWithProvider(ui) {
+  return render(<EmployeeProvider>{ui}</EmployeeProvider>);
+}
+
+describe('EmployeesPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fetches and displays employees on load', async () => {
+    service.getEmployees.mockResolvedValue([
+      { id: 1, name: 'John', role: 'Dev', department: 'IT', doj: '2023-01-01', status: 'Active' },
+    ]);
+    renderWithProvider(<EmployeesPage />);
+    expect(service.getEmployees).toHaveBeenCalled();
+    expect(await screen.findByText('John')).toBeInTheDocument();
+  });
+
+  test('shows error toast if fetch fails', async () => {
+    service.getEmployees.mockRejectedValue(new Error('network'));
+    renderWithProvider(<EmployeesPage />);
+    expect(await screen.findByText('network')).toBeInTheDocument();
+  });
+
+  test('creates employee and refreshes list', async () => {
+    service.getEmployees.mockResolvedValueOnce([]);
+    service.createEmployee.mockResolvedValueOnce([
+      { id: 1, name: 'Alice', role: 'Dev', department: 'IT', doj: '2023-01-01', status: 'Active' },
+    ]);
+
+    renderWithProvider(<EmployeesPage />);
+
+    fireEvent.click(screen.getByText('Add Employee'));
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Alice' } });
+    fireEvent.change(screen.getByLabelText('Role'), { target: { value: 'Dev' } });
+    fireEvent.change(screen.getByLabelText('Department'), { target: { value: 'IT' } });
+    fireEvent.change(screen.getByLabelText('Date of Joining'), { target: { value: '2023-01-01' } });
+    fireEvent.change(screen.getByLabelText('Status'), { target: { value: 'Active' } });
+
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(service.createEmployee).toHaveBeenCalled());
+    expect(await screen.findByText('Employee added')).toBeInTheDocument();
+    expect(await screen.findByText('Alice')).toBeInTheDocument();
+  });
+
+  test('submit button disabled while submitting', async () => {
+    service.getEmployees.mockResolvedValue([]);
+    let resolve;
+    service.createEmployee.mockReturnValue(new Promise((res) => { resolve = res; }));
+
+    renderWithProvider(<EmployeesPage />);
+    fireEvent.click(screen.getByText('Add Employee'));
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Bob' } });
+    fireEvent.change(screen.getByLabelText('Role'), { target: { value: 'Dev' } });
+    fireEvent.change(screen.getByLabelText('Department'), { target: { value: 'IT' } });
+    fireEvent.change(screen.getByLabelText('Date of Joining'), { target: { value: '2023-01-01' } });
+    fireEvent.change(screen.getByLabelText('Status'), { target: { value: 'Active' } });
+
+    const save = screen.getByText('Save');
+    fireEvent.click(save);
+    expect(save.closest('button')).toBeDisabled();
+
+    resolve([]);
+    await waitFor(() => expect(service.createEmployee).toHaveBeenCalled());
+  });
+});

--- a/src/services/employeeService.js
+++ b/src/services/employeeService.js
@@ -1,0 +1,24 @@
+const API_BASE = 'http://172.18.4.178:8000';
+
+export async function getEmployees() {
+  const res = await fetch(`${API_BASE}/employees`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch employees');
+  }
+  return res.json();
+}
+
+export async function createEmployee(data) {
+  const res = await fetch(`${API_BASE}/employees`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to create employee');
+  }
+  await res.text();
+  return getEmployees();
+}


### PR DESCRIPTION
## Summary
- refactor EmployeesPage to use employeeService
- optimize component with hooks
- add unit tests for EmployeesPage

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851149858e88332b8c3f272532176b8

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor the `EmployeesPage` component to utilize the new `employeeService` for fetching and creating employees, enhancing code modularity and maintainability; and add unit tests for the `EmployeesPage` to ensure functionality.

### Why are these changes being made?
The introduction of `employeeService` abstracts API interactions, making the `EmployeesPage` cleaner and more maintainable by decoupling business logic from UI code. Unit tests ensure the reliability of the page's functionality, especially for fetching, creating, and handling state changes for employees. This approach allows for better test coverage and more straightforward code updates or bug fixes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->